### PR TITLE
#167072858 Admin can create trip

### DIFF
--- a/src/controllers/TripController.js
+++ b/src/controllers/TripController.js
@@ -17,6 +17,12 @@ export default class TripController {
   }
 
   static create(req, res, next) {
-
+    const trips = Trip.create(req.body);
+    return res.status(201).json({
+      status: 'success',
+      data: {
+        trips,
+      },
+    });
   }
 }

--- a/src/controllers/TripController.js
+++ b/src/controllers/TripController.js
@@ -17,11 +17,11 @@ export default class TripController {
   }
 
   static create(req, res, next) {
-    const trips = Trip.create(req.body);
+    const trip = Trip.create(req.body);
     return res.status(201).json({
       status: 'success',
       data: {
-        trips,
+        trip,
       },
     });
   }

--- a/src/middlewares/CreateTripMiddleware.js
+++ b/src/middlewares/CreateTripMiddleware.js
@@ -1,0 +1,79 @@
+import { checkSchema } from 'express-validator';
+
+export default checkSchema({
+  bus_id: {
+    in: ['body'],
+    exists: {
+      errorMessage: 'Bus ID is required',
+    },
+    trim: true,
+    isEmpty: {
+      errorMessage: 'Bus ID cannot be empty',
+      negated: true,
+    },
+    toInt: true,
+  },
+  origin: {
+    in: ['body'],
+    exists: {
+      errorMessage: 'Origin is required',
+    },
+    trim: true,
+    isEmpty: {
+      errorMessage: 'Origin cannot be empty',
+      negated: true,
+    },
+  },
+  destination: {
+    in: ['body'],
+    exists: {
+      errorMessage: 'Destination is required',
+    },
+    trim: true,
+    isEmpty: {
+      errorMessage: 'Destination cannot be empty',
+      negated: true,
+    },
+  },
+  trip_date: {
+    in: ['body'],
+    exists: {
+      errorMessage: 'Trip Date is required',
+    },
+    trim: true,
+    isEmpty: {
+      errorMessage: 'Trip Date cannot be empty',
+      negated: true,
+    },
+    // https://stackoverflow.com/questions/6177975/how-to-validate-date-with-format-mm-dd-yyyy-in-javascript
+    custom: {
+      errorMessage: 'Fare is invalid',
+      options: (value) => {
+        if (!value.trim()) return false;
+        const regex = /^\d{4}-\d{1,2}-\d{1,2}$/;
+        return (regex.test(value));
+      },
+    },
+  },
+  fare: {
+    in: ['body'],
+    exists: {
+      errorMessage: 'Fare is required',
+    },
+    trim: true,
+    isEmpty: {
+      errorMessage: 'Fare cannot be empty',
+      negated: true,
+    },
+    // https://www.codeproject.com/Questions/475669/Onlyplusoneplusdecimalpluspointplusinplustextplusb
+    custom: {
+      errorMessage: 'Fare is invalid',
+      options: (value) => {
+        if (!value.trim()) return false;
+        const regex = /^[0-9]+\.?[0-9]*$/;
+        return (regex.test(value));
+      },
+    },
+    toFloat: true,
+  },
+});

--- a/src/middlewares/IsAdminMiddleware.js
+++ b/src/middlewares/IsAdminMiddleware.js
@@ -1,0 +1,19 @@
+import jwt from 'jsonwebtoken';
+import Config from '../config/index';
+import ErrorHandler from '../util/ErrorHandler';
+import User from '../model/User';
+
+
+const { secret: SECRET_KEY } = Config;
+
+export default function (req, res, next) {
+  const token = req.headers.authorization;
+  try {
+    const decoded = jwt.verify(token, SECRET_KEY);
+    const { id } = decoded;
+    const isAdmin = User.isAdmin(id);
+    return isAdmin ? next() : next(ErrorHandler.error('Unauthorized', 403));
+  } catch (error) {
+    return next(ErrorHandler.error(error.message, 401));
+  }
+}

--- a/src/middlewares/IsAdminMiddleware.js
+++ b/src/middlewares/IsAdminMiddleware.js
@@ -8,12 +8,8 @@ const { secret: SECRET_KEY } = Config;
 
 export default function (req, res, next) {
   const token = req.headers.authorization;
-  try {
-    const decoded = jwt.verify(token, SECRET_KEY);
-    const { id } = decoded;
-    const isAdmin = User.isAdmin(id);
-    return isAdmin ? next() : next(ErrorHandler.error('Unauthorized', 403));
-  } catch (error) {
-    return next(ErrorHandler.error(error.message, 401));
-  }
+  const decoded = jwt.verify(token, SECRET_KEY);
+  const { id } = decoded;
+  const isAdmin = User.isAdmin(id);
+  return isAdmin ? next() : next(ErrorHandler.error('Unauthorized', 403));
 }

--- a/src/model/Trip.js
+++ b/src/model/Trip.js
@@ -2,6 +2,20 @@ import TripSeed from '../db/seeds/trips';
 import QueryBuilder from '../db/QueryBuilder';
 
 export default class Trip extends QueryBuilder {
+  static create(data) {
+    const trips = {
+      id: (TripSeed.length + 1),
+      bus_id: data.bus_id,
+      origin: data.origin,
+      destination: data.destination,
+      trip_date: data.trip_date,
+      fare: data.fare,
+      status: 1,
+    };
+    TripSeed.push(trips);
+    return trips;
+  }
+
   static getAll() {
     return TripSeed;
   }

--- a/src/model/User.js
+++ b/src/model/User.js
@@ -14,6 +14,6 @@ export default class User extends QueryBuilder {
 
   static isAdmin(id) {
     if (!id) return false;
-    return UserSeed.find(user => user.id === id);
+    return UserSeed.find(user => user.id === id && user.is_admin === 1);
   }
 }

--- a/src/model/User.js
+++ b/src/model/User.js
@@ -4,12 +4,16 @@ import QueryBuilder from '../db/QueryBuilder';
 const TABLE = 'users';
 
 export default class User extends QueryBuilder {
-
   static exists(data) {
     return UserSeed.find(user => user.email === data.email);
   }
 
   static create(data) {
     return super.create(UserSeed, data);
+  }
+
+  static isAdmin(id) {
+    if (!id) return false;
+    return UserSeed.find(user => user.id === id);
   }
 }

--- a/src/routes/trips.js
+++ b/src/routes/trips.js
@@ -1,10 +1,13 @@
 import express from 'express';
 import AuthMiddleware from '../middlewares/AuthMiddleware';
+import IsAdminMiddleware from '../middlewares/IsAdminMiddleware';
+import CreateTripMiddleware from '../middlewares/CreateTripMiddleware';
 import TripController from '../controllers/TripController';
+import ValidationErrors from '../middlewares/ValidationErrors';
 
 const router = express.Router();
 
 router.get('/trips', AuthMiddleware, TripController.view);
-// router.post('/trips', AuthMiddleware, ValidationErrors, AuthController.register);
+router.post('/trips', AuthMiddleware, IsAdminMiddleware, CreateTripMiddleware, ValidationErrors, TripController.create);
 
 export default router;

--- a/test/trips.js
+++ b/test/trips.js
@@ -15,6 +15,14 @@ const admin = {
   password: '123456',
 };
 
+const trip = {
+  bus_id: 1,
+  origin: 'Ikorodu',
+  destination: 'Maryland',
+  trip_date: '2019-06-27',
+  fare: 123,
+};
+
 let userToken;
 let adminToken;
 describe('Test Trip route', () => {
@@ -28,14 +36,14 @@ describe('Test Trip route', () => {
       });
     chai.request(app)
       .post(`${base}auth/signin`)
-      .send(user)
+      .send(admin)
       .end((err, res) => {
         adminToken = res.body.data.token;
         expect(res.status).to.equal(201);
         done();
       });
   });
-  describe('View all trips', () => {
+  describe('Test view all trips', () => {
     describe('Unauthenticated users can not view trips', () => {
       it('should respond with status 401 and error message for token absent', (done) => {
         chai.request(app)
@@ -68,6 +76,307 @@ describe('Test Trip route', () => {
             expect(res.status).to.equal(200);
             expect(res.body).to.have.property('status', 'success');
             expect(res.body.data).to.have.property('trips');
+            done();
+          });
+      });
+    });
+  });
+  describe('Test trips can be created', () => {
+    describe('Users can not create trip', () => {
+      it('should respond with status 403 and error message', (done) => {
+        chai.request(app)
+          .post(`${base}trips`)
+          .set('Authorization', userToken)
+          .send(trip)
+          .end((err, res) => {
+            expect(res.status).to.equal(403);
+            expect(res.body).to.have.property('status', 'error');
+            expect(res.body).to.have.property('error');
+            done();
+          });
+      });
+    });
+    describe('Admin cannot create trip data with invalid credentials', () => {
+      describe('Test bus id field', () => {
+        it('should respond with error for missing bus id field', (done) => {
+          chai.request(app)
+            .post(`${base}trips`)
+            .set('Authorization', adminToken)
+            .send({
+              origin: 'Ikorodu',
+              destination: 'Maryland',
+              trip_date: '2019-06-27',
+              fare: 123,
+            })
+            .end((err, res) => {
+              expect(res.status).to.equal(422);
+              expect(res.body).to.have.property('status', 'error');
+              expect(res.body).to.have.property('error');
+              const data = JSON.parse(res.body.error);
+              const error = data.find(key => key.field === 'bus_id');
+              expect(data).to.be.an('array');
+              expect(error).to.be.an('object');
+              done();
+            });
+        });
+        it('should respond with error for empty bus id field', (done) => {
+          chai.request(app)
+            .post(`${base}trips`)
+            .set('Authorization', adminToken)
+            .send({
+              bus_id: '',
+              origin: 'Ikorodu',
+              destination: 'Maryland',
+              trip_date: '2019-06-27',
+              fare: 123,
+            })
+            .end((err, res) => {
+              expect(res.status).to.equal(422);
+              expect(res.body).to.have.property('status', 'error');
+              expect(res.body).to.have.property('error');
+              const data = JSON.parse(res.body.error);
+              const error = data.find(key => key.field === 'bus_id');
+              expect(data).to.be.an('array');
+              expect(error).to.be.an('object');
+              done();
+            });
+        });
+      });
+      describe('Test destination field', () => {
+        it('should respond with error for missing destination field', (done) => {
+          chai.request(app)
+            .post(`${base}trips`)
+            .set('Authorization', adminToken)
+            .send({
+              bus_id: 4,
+              origin: 'Ikorodu',
+              trip_date: '2019-06-27',
+              fare: 123,
+            })
+            .end((err, res) => {
+              expect(res.status).to.equal(422);
+              expect(res.body).to.have.property('status', 'error');
+              expect(res.body).to.have.property('error');
+              const data = JSON.parse(res.body.error);
+              const error = data.find(key => key.field === 'destination');
+              expect(data).to.be.an('array');
+              expect(error).to.be.an('object');
+              done();
+            });
+        });
+        it('should respond with error for empty destination field', (done) => {
+          chai.request(app)
+            .post(`${base}trips`)
+            .set('Authorization', adminToken)
+            .send({
+              bus_id: 3,
+              origin: 'Ikorodu',
+              destination: '',
+              trip_date: '2019-06-27',
+              fare: 123,
+            })
+            .end((err, res) => {
+              expect(res.status).to.equal(422);
+              expect(res.body).to.have.property('status', 'error');
+              expect(res.body).to.have.property('error');
+              const data = JSON.parse(res.body.error);
+              const error = data.find(key => key.field === 'destination');
+              expect(data).to.be.an('array');
+              expect(error).to.be.an('object');
+              done();
+            });
+        });
+      });
+      describe('Test trip date field', () => {
+        it('should respond with error for missing trip date field', (done) => {
+          chai.request(app)
+            .post(`${base}trips`)
+            .set('Authorization', adminToken)
+            .send({
+              bus_id: 1,
+              origin: 'Ikorodu',
+              destination: 'Maryland',
+              fare: 123,
+            })
+            .end((err, res) => {
+              expect(res.status).to.equal(422);
+              expect(res.body).to.have.property('status', 'error');
+              expect(res.body).to.have.property('error');
+              const data = JSON.parse(res.body.error);
+              const error = data.find(key => key.field === 'trip_date');
+              expect(data).to.be.an('array');
+              expect(error).to.be.an('object');
+              done();
+            });
+        });
+        it('should respond with error for empty trip date field', (done) => {
+          chai.request(app)
+            .post(`${base}trips`)
+            .set('Authorization', adminToken)
+            .send({
+              bus_id: 6,
+              origin: 'Ikorodu',
+              destination: 'Maryland',
+              trip_date: '',
+              fare: 123,
+            })
+            .end((err, res) => {
+              expect(res.status).to.equal(422);
+              expect(res.body).to.have.property('status', 'error');
+              expect(res.body).to.have.property('error');
+              const data = JSON.parse(res.body.error);
+              const error = data.find(key => key.field === 'trip_date');
+              expect(data).to.be.an('array');
+              expect(error).to.be.an('object');
+              done();
+            });
+        });
+        it('should respond with error for invalid trip date field', (done) => {
+          chai.request(app)
+            .post(`${base}trips`)
+            .set('Authorization', adminToken)
+            .send({
+              bus_id: 6,
+              origin: 'Ikorodu',
+              destination: 'Maryland',
+              trip_date: 'HelloWorld',
+              fare: 123,
+            })
+            .end((err, res) => {
+              expect(res.status).to.equal(422);
+              expect(res.body).to.have.property('status', 'error');
+              expect(res.body).to.have.property('error');
+              const data = JSON.parse(res.body.error);
+              const error = data.find(key => key.field === 'trip_date');
+              expect(data).to.be.an('array');
+              expect(error).to.be.an('object');
+              done();
+            });
+        });
+      });
+      describe('Test fare field', () => {
+        it('should respond with error for missing fare field', (done) => {
+          chai.request(app)
+            .post(`${base}trips`)
+            .set('Authorization', adminToken)
+            .send({
+              bus_id: 1,
+              origin: 'Ikorodu',
+              destination: 'Maryland',
+              trip_date: '2019-03-16',
+            })
+            .end((err, res) => {
+              expect(res.status).to.equal(422);
+              expect(res.body).to.have.property('status', 'error');
+              expect(res.body).to.have.property('error');
+              const data = JSON.parse(res.body.error);
+              const error = data.find(key => key.field === 'fare');
+              expect(data).to.be.an('array');
+              expect(error).to.be.an('object');
+              done();
+            });
+        });
+        it('should respond with error for empty fare field', (done) => {
+          chai.request(app)
+            .post(`${base}trips`)
+            .set('Authorization', adminToken)
+            .send({
+              bus_id: 6,
+              origin: 'Ikorodu',
+              destination: 'Maryland',
+              trip_date: '2019-08-16',
+              fare: '',
+            })
+            .end((err, res) => {
+              expect(res.status).to.equal(422);
+              expect(res.body).to.have.property('status', 'error');
+              expect(res.body).to.have.property('error');
+              const data = JSON.parse(res.body.error);
+              const error = data.find(key => key.field === 'fare');
+              expect(data).to.be.an('array');
+              expect(error).to.be.an('object');
+              done();
+            });
+        });
+        it('should respond with error for invalid fare field', (done) => {
+          chai.request(app)
+            .post(`${base}trips`)
+            .set('Authorization', adminToken)
+            .send({
+              bus_id: 6,
+              origin: 'Ikorodu',
+              destination: 'Maryland',
+              trip_date: '2019-07-08',
+              fare: '99YDa',
+            })
+            .end((err, res) => {
+              expect(res.status).to.equal(422);
+              expect(res.body).to.have.property('status', 'error');
+              expect(res.body).to.have.property('error');
+              const data = JSON.parse(res.body.error);
+              const error = data.find(key => key.field === 'fare');
+              expect(data).to.be.an('array');
+              expect(error).to.be.an('object');
+              done();
+            });
+        });
+      });
+      describe('Test origin field', () => {
+        it('should respond with error for missing origin field', (done) => {
+          chai.request(app)
+            .post(`${base}trips`)
+            .set('Authorization', adminToken)
+            .send({
+              bus_id: 4,
+              destination: 'Maryland',
+              trip_date: '2019-06-27',
+              fare: 123,
+            })
+            .end((err, res) => {
+              expect(res.status).to.equal(422);
+              expect(res.body).to.have.property('status', 'error');
+              expect(res.body).to.have.property('error');
+              const data = JSON.parse(res.body.error);
+              const error = data.find(key => key.field === 'origin');
+              expect(data).to.be.an('array');
+              expect(error).to.be.an('object');
+              done();
+            });
+        });
+        it('should respond with error for empty origin field', (done) => {
+          chai.request(app)
+            .post(`${base}trips`)
+            .set('Authorization', adminToken)
+            .send({
+              bus_id: 9,
+              origin: '',
+              destination: 'Maryland',
+              trip_date: '2019-06-27',
+              fare: 123,
+            })
+            .end((err, res) => {
+              expect(res.status).to.equal(422);
+              expect(res.body).to.have.property('status', 'error');
+              expect(res.body).to.have.property('error');
+              const data = JSON.parse(res.body.error);
+              const error = data.find(key => key.field === 'origin');
+              expect(data).to.be.an('array');
+              expect(error).to.be.an('object');
+              done();
+            });
+        });
+      });
+    });
+    describe('Admin can create trip', () => {
+      it('should respond with status 201 and trip data', (done) => {
+        chai.request(app)
+          .post(`${base}trips`)
+          .set('Authorization', adminToken)
+          .send(trip)
+          .end((err, res) => {
+            expect(res.status).to.equal(201);
+            expect(res.body).to.have.property('status', 'success');
+            expect(res.body.data).to.have.property('trip');
             done();
           });
       });


### PR DESCRIPTION
**What does this PR do?**
Allow admins to create a trip

**Description of Task to be completed?**
 - Check user is an admin and validate data
 - Store trip data
 - Respond with created trip data

**How should this be manually tested?**
- `git clone https://github.com/Steelze/wayfarer.git`
- `cd wayfarer`
- `git checkout ft-create-trip-167072858`
- `npm install`
- `npm run start-dev`
- Send post request to `/api/v1/trips` with bus_id, origin, destination, trip_date and fare fields

**What are the relevant pivotal tracker stories?**
#167072858