### PR TITLE
[feature #167219839] Admin can view buses

### DIFF
--- a/src/controllers/BusController.js
+++ b/src/controllers/BusController.js
@@ -6,7 +6,19 @@ import QueryBuilder from '../db/QueryBuilder';
  */
 
 export default class BusController {
-  static async view(req, res, next) {  
+  static async view(req, res, next) {
+    try {
+      const data = await QueryBuilder.select('buses');
+      const buses = data.rows;
+      return res.status(200).json({
+        status: 'success',
+        data: {
+          buses,
+        },
+      });
+    } catch (error) {
+      return next(error);
+    }
   }
 
   static async create(req, res, next) {

--- a/src/middlewares/CreateBusMiddleware.js
+++ b/src/middlewares/CreateBusMiddleware.js
@@ -26,11 +26,11 @@ export default checkSchema({
   manufacturer: {
     in: ['body'],
     exists: {
-      errorMessage: 'Manufactureu is required',
+      errorMessage: 'Manufacturer is required',
     },
     trim: true,
     isEmpty: {
-      errorMessage: 'Manufactureu cannot be empty',
+      errorMessage: 'Manufacturer cannot be empty',
       negated: true,
     },
   },

--- a/test/buses.js
+++ b/test/buses.js
@@ -51,6 +51,34 @@ describe('Test Buses route', () => {
       });
     await QueryBuilder.update('users', { is_admin: true }, { email: admin.email });
   });
+  describe('Test buses can be viewed', () => {
+    describe('Users can not view buses', () => {
+      it('should respond with status 403 and error message', (done) => {
+        chai.request(app)
+          .get(`${base}buses`)
+          .set('Authorization', user_token)
+          .end((err, res) => {
+            expect(res.status).to.equal(403);
+            expect(res.body).to.have.property('status', 'error');
+            expect(res.body).to.have.property('error');
+            done();
+          });
+      });
+    });
+    describe('Admins can view buses', () => {
+      it('should respond with status 200 and error message', (done) => {
+        chai.request(app)
+          .get(`${base}buses`)
+          .set('Authorization', admin_token)
+          .end((err, res) => {
+            expect(res.status).to.equal(200);
+            expect(res.body).to.have.property('status', 'success');
+            expect(res.body.data).to.have.property('buses');
+            done();
+          });
+      });
+    });
+  });
   describe('Test buses can be created', () => {
     describe('Users can not create buses', () => {
       it('should respond with status 403 and error message', (done) => {


### PR DESCRIPTION
**What does this PR do?**
Allows admin to view all buses on the system

**How should this be manually tested?**
- `git clone https://github.com/Steelze/wayfarer.git`
- `cd wayfarer`
- `git checkout ft-view-buses-167219839`
- `npm install`
- Setup PostgreSQL database
- `npm run start-dev`
- Send a get request to `api/v1/buses`

**What are the relevant pivotal tracker stories?**
#167219839